### PR TITLE
Perform :update instead of :write on autowrite.

### DIFF
--- a/plugin/makejob.vim
+++ b/plugin/makejob.vim
@@ -178,7 +178,7 @@ function! s:MakeJob(grep, lmake, grepadd, bang, ...) abort
     silent execute s:InitAutocmd(a:lmake, a:grep, 'Pre')
 
     if &autowrite && !empty(bufname('%')) && !a:grep
-        silent write
+        silent update
     endif
 
     if l:internal_grep


### PR DESCRIPTION
Currently, :MakeJob always writes the file, even if it is not modified, resulting in a rebuild every time. However, :make with autowrite only writes the file if it is modified.

This changes the behaviour of :MakeJob to match :make by using :update instead of :write.