### PR TITLE
Give the {quickfix,location} list window nicer title.

### DIFF
--- a/plugin/makejob.vim
+++ b/plugin/makejob.vim
@@ -80,6 +80,11 @@ function! s:JobHandler(channel) abort
         silent execute bufwinnr(l:job['outbufnr']).'close'
     endif
     silent execute l:qfcmd.' '.l:job['outbufnr']
+    if l:job['lmake']
+      call setloclist(0, [], 'a', {'title':l:job['prog']})
+    else
+      call setqflist([], 'a', {'title':l:job['prog']})
+    endif
     silent execute l:job['outbufnr'].'bwipe!' 
     execute l:curwinnr.'wincmd w'
 


### PR DESCRIPTION
Currently, the name of quickfix/location list window is something like ":cgetbuffer 2 (make)".

This changes the title to the 'prog' (i.e., mostly "make" or "grep"), the same what the preview window uses.