### PR TITLE
Automatic opening of quickfix/localtion list window.

### DIFF
--- a/plugin/makejob.vim
+++ b/plugin/makejob.vim
@@ -111,7 +111,12 @@ function! s:JobHandler(channel) abort
     echomsg l:job['prog']." ended with ".l:makeoutput." findings"
 endfunction
 
-function! s:CreateMakeJobBuffer(prog)
+function! s:CreateMakeJobBuffer(prog, lmake)
+    if a:lmake
+      lclose
+    else
+      cclose
+    endif
     silent execute 'belowright 10split '.a:prog
     setlocal bufhidden=hide buftype=nofile buflisted nolist
     setlocal noswapfile nowrap nomodifiable
@@ -192,7 +197,7 @@ function! s:MakeJob(grep, lmake, grepadd, bang, ...) abort
         execute l:make
         return
     else
-        let l:outbufnr = s:CreateMakeJobBuffer(prog)
+        let l:outbufnr = s:CreateMakeJobBuffer(prog, a:lmake)
 
         let l:makejob = job_start(l:make, l:opts)
         let b:makejob = l:makejob

--- a/plugin/makejob.vim
+++ b/plugin/makejob.vim
@@ -98,7 +98,14 @@ function! s:JobHandler(channel) abort
     silent execute s:InitAutocmd(l:job['lmake'], l:job['grep'], 'Post')
 
     if l:job['cfirst']
-        silent! cfirst
+        if l:makeoutput > 0
+            if l:job['lmake']
+              lopen
+            else
+              copen
+            endif
+            execute l:curwinnr.'wincmd w'
+        end
     end
 
     echomsg l:job['prog']." ended with ".l:makeoutput." findings"


### PR DESCRIPTION
This is an initial attempt, I am definitely open to apply changes we discuss.

This pull request discusses only the bang-less usage of :MakeJob and friends. Also when I say quickfix window, I mean location list when appropriate.

Currently, :MakeJob after finishing calls :cfirst, which
- always moves the cursor to the beginning of line (even when in insert mode), which is disturbing
- it activates the first line, not the first valid line in the qf window

The :make without bang jumps to the first error, which is a bit different behaviour.

What I propose is to open quickfix/location list automatically if there are any errors (i.e., "findings"), with the first valid line selected, and all this without moving the cursor. Therefore, if the :MakeJob finishes with errors, the preview window is "replaced" by the quickfix window, with the first error selected, without disturbing the user. The error is visible, so when they see fit, they can look at it and possibly go to it (using :cc or <C-w> <Cr>).

To contribute to a smooth workflow, :MakeJob now also closes the quickfix window on start. Otherwise, if there is an quickfix window + preview window during next build.

If you want, the behaviour can be configurable (maybe by two options, something like `g:makejob_hide_qfloc_on_start`, and `g:makejob_open_qfloc_on_error`).