### PR TITLE
Fixed plugin/makejob.vim line 222 : E181: Invalid attribute: bar-nargs=*

### DIFF
--- a/plugin/makejob.vim
+++ b/plugin/makejob.vim
@@ -219,7 +219,7 @@ function! s:MakeJobCompletion(arglead, cmdline, cursorpos)
     return l:return
 endfunction
 
-command! -bang  -bar-nargs=* -complete=file MakeJob
+command! -bang -bar -nargs=* -complete=file MakeJob
             \ call <sid>MakeJob(0,0,0,<bang>0,<q-args>)
 command! -bang -bar -nargs=* -complete=file LmakeJob
             \ call <sid>MakeJob(0,1,0,<bang>0,<q-args>)


### PR DESCRIPTION
In line 222, between `-bar` and `-nargs=*` missed a space